### PR TITLE
feat: composer and packages to handle wpcs && fixed wpcs violations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+.phpcs.cache
+composer.lock

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<ruleset name="CS">
+    <description>Product Fields Admin</description>
+    <config name="testVersion" value="5.6-"/>
+    <exclude-pattern>vendor/*</exclude-pattern>
+
+    <arg value="ps"/>
+    <arg name="colors"/>
+    <arg name="parallel" value="100"/>
+    <arg name="extensions" value="php"/>
+    <arg name="cache" value=".phpcs.cache"/>
+
+    <rule ref="WordPress"/>
+
+    <rule ref="WordPress-Extra"/>
+
+    <rule ref="WordPress-Docs"/>
+
+    <rule ref="Generic.Metrics.CyclomaticComplexity">
+        <properties>
+            <property name="complexity" value="3"/>
+            <property name="absoluteComplexity" value="5"/>
+        </properties>
+    </rule>
+
+    <rule ref="Generic.Metrics.NestingLevel">
+        <properties>
+            <property name="absoluteNestingLevel" value="3"/>
+        </properties>
+    </rule>
+
+    <!-- Allow short array syntax -->
+    <rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax.Found"/>
+</ruleset>

--- a/class-product-fields-admin.php
+++ b/class-product-fields-admin.php
@@ -1,5 +1,6 @@
 <?php
 /**
+ *
  * Plugin Main Class File
  *
  * @package Product_Fields_Admin
@@ -10,103 +11,116 @@ defined( 'ABSPATH' ) || exit;
 class Init {
 
 	protected static $instance = null;
-    
 
-    public function __construct() {
+	public function __construct() {
 
-        add_action( 'woocommerce_product_options_general_product_data', [$this,'register_wc_product_custom_fields' ]);
-        add_action( 'woocommerce_process_product_meta', [$this,'save_wc_product_custom_fields' ]);
-        add_action( 'woocommerce_before_add_to_cart_button', [$this, 'display_wc_product_custom_fields']);
-        add_filter( 'woocommerce_add_to_cart_validation', [$this, 'validate_wc_custom_fields' ], 10, 3);
-        add_filter( 'woocommerce_add_cart_item_data', [$this, 'add_wc_custom_field_to_cart_metadata' ] , 10 , 4);
-        add_filter( 'woocommerce_cart_item_name', [$this,'add_wc_custom_field_cart_checkout' ], 10, 3);
-        add_action( 'woocommerce_checkout_create_order_line_item', [$this,'add_wc_custom_field_to_order' ], 10, 4);
+		add_action( 'woocommerce_product_options_general_product_data', [ $this, 'register_wc_product_custom_fields' ] );
+		add_action( 'woocommerce_process_product_meta', [ $this, 'save_wc_product_custom_fields' ] );
+		add_action( 'woocommerce_before_add_to_cart_button', [ $this, 'display_wc_product_custom_fields' ] );
+		add_filter( 'woocommerce_add_to_cart_validation', [ $this, 'validate_wc_custom_fields' ], 10, 3 );
+		add_filter( 'woocommerce_add_cart_item_data', [ $this, 'add_wc_custom_field_to_cart_metadata' ], 10, 4 );
+		add_filter( 'woocommerce_cart_item_name', [ $this, 'add_wc_custom_field_cart_checkout' ], 10, 3 );
+		add_action( 'woocommerce_checkout_create_order_line_item', [ $this, 'add_wc_custom_field_to_order' ], 10, 4 );
 
-    }
+	}
 
-    // Register Custom Fields
-    public function register_wc_product_custom_fields() {
-        global $woocommerce, $post;
-        echo '<div class="product_custom_field">';
-        woocommerce_wp_text_input(
-            array(
-                'id'          => 'custom_product_text_field',
-                'placeholder' => 'Custom Product Text Field',
-                'label'       => 'Custom Product Text Field',
-                'desc_tip'    => 'true',
-            )
-        );
-	    echo '</div>';
-}
+	/**
+	 * Register Custom Fields
+	 */
+	public function register_wc_product_custom_fields() {
+		global $woocommerce, $post;
+		echo '<div class="product_custom_field">';
+		woocommerce_wp_text_input(
+			[
+				'id'          => 'custom_product_text_field',
+				'placeholder' => 'Custom Product Text Field',
+				'label'       => 'Custom Product Text Field',
+				'desc_tip'    => 'true',
+			]
+		);
+		echo '</div>';
+	}
 
-    // Save Fields
-    public function save_wc_product_custom_fields ( $post_id ) {
+	/**
+	 * Save Fields
+	 */
+	public function save_wc_product_custom_fields( $post_id ) {
 
-        $product = wc_get_product( $post_id );
-        $title = isset( $_POST['custom_product_text_field'] ) ? $_POST['custom_product_text_field'] : '';
-        $product->update_meta_data( 'custom_product_text_field', sanitize_text_field( $title ) );
-        $product->save();
-    }
+		$product = wc_get_product( $post_id );
+		$title   = isset( $_POST['custom_product_text_field'] ) ? $_POST['custom_product_text_field'] : '';
+		$product->update_meta_data( 'custom_product_text_field', sanitize_text_field( $title ) );
+		$product->save();
+	}
 
-    // Display the fields in the product page
-    public function display_wc_product_custom_fields() {
-        global $post;
-    
-        $product = wc_get_product($post->ID);
+	/**
+	 * Display the fields in the product page
+	 */
+	public function display_wc_product_custom_fields() {
+		global $post;
 
-        $title = $product->get_meta('custom_product_text_field');
-    
-        if ($title) {
-            printf(
+		$product = wc_get_product( $post->ID );
 
-                '<div><label for="">%s</label>
+		$title = $product->get_meta( 'custom_product_text_field' );
+
+		if ( $title ) {
+			printf(
+				'<div><label for="">%s</label>
                     <input type="text" id="wc-custom-field" name="wc-custom-field" value="">
                 </div>',
+				esc_html( $title )
+			);
+		}
+	}
 
-                esc_html($title)
-            );
-    }
-}
+	/**
+	 * Validate user input
+	 */
+	public function validate_wc_custom_fields( $passed, $product_id, $quantity ) {
+		if ( empty( $_POST['wc-custom-field'] ) ) {
+			$passed = false;
+			wc_add_notice( 'Please enter a value into the text field', 'error' );
+		}
+		return $passed;
 
-    // Validate user input
-    public function validate_wc_custom_fields( $passed, $product_id, $quantity ) {
-        if( empty( $_POST['wc-custom-field'] ) ) {
-            $passed = false;
-            wc_add_notice( 'Please enter a value into the text field', 'error' );
-        }
-        return $passed;
-        
-    }
+	}
 
-    // Add the user input from the previous custom field to cart meta data
-    public function add_wc_custom_field_to_cart_metadata( $cart_item_data, $product_id, $variation_id, $quantity ) {
-        if( ! empty( $_POST['wc-custom-field'] ) ) {
-            $cart_item_data['title_field'] = $_POST['wc-custom-field'];
-        }
-    return $cart_item_data;
-    }
+	/**
+	 * Add the user input from the previous custom field to cart meta data
+	 */
+	public function add_wc_custom_field_to_cart_metadata( $cart_item_data, $product_id, $variation_id, $quantity ) {
+		if ( ! empty( $_POST['wc-custom-field'] ) ) {
+			$cart_item_data['title_field'] = $_POST['wc-custom-field'];
+		}
+		return $cart_item_data;
+	}
 
-// Display the value from the custom field to the cart && checkout pages
-    public function add_wc_custom_field_cart_checkout( $name, $cart_item, $cart_item_key ) {
-        if( isset( $cart_item['title_field'] ) ) {
-            $name .= sprintf(
-                '<p>%s</p>',
-                esc_html( $cart_item['title_field'] )
-            );
-        }
-        return $name;
-    }
+	/**
+	 * Display the value from the custom field to the cart && checkout pages
+	 */
+	public function add_wc_custom_field_cart_checkout( $name, $cart_item, $cart_item_key ) {
+		if ( isset( $cart_item['title_field'] ) ) {
+			$name .= sprintf(
+				'<p>%s</p>',
+				esc_html( $cart_item['title_field'] )
+			);
+		}
+		return $name;
+	}
 
-// Add custom field to order object
-    function add_wc_custom_field_to_order( $item, $cart_item_key, $values, $order ) {
-        foreach( $item as $cart_item_key=>$values ) {
-                if( isset( $values['title_field'] ) ) {
-                    $item->add_meta_data('Custom Field', $values['title_field'], true );
-                }
-            }
-        }
+	/**
+	 * Add custom field to order object
+	 */
+	public function add_wc_custom_field_to_order( $item, $cart_item_key, $values, $order ) {
+		foreach ( $item as $cart_item_key => $values ) {
+			if ( isset( $values['title_field'] ) ) {
+				$item->add_meta_data( 'Custom Field', $values['title_field'], true );
+			}
+		}
+	}
 
-	// Return the single class instance.
+	/**
+	 * Return the single class instance
+	 */
 	public static function get_instance() {
 		if ( null === self::$instance ) {
 			self::$instance = new self();

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,33 @@
+{
+  "name": "sarahcssiqueira/product-fields-admin",
+  "description": "Plugin to create and manage custom product fields for WooCommerce.",
+  "license": "GPL-2.0+",
+  "type": "wordpress-plugin",
+  "authors": [
+    {
+      "name": "sarahcssiqueira",
+      "email": "sarahcosiqueira@gmail.com",
+      "homepage": "https://sarahjobs.com"
+    }
+  ],
+  "support": {
+    "src": "https://github.com/sarahcssiqueira/product-fields-admin",
+    "issues": "https://github.com/sarahcssiqueira/product-fields-admin/issues"
+  },
+  "autoload": {
+    "psr-4": {
+      "ProductFieldsAdmin\\": "./"
+    }
+  },
+  "require": {},
+  "scripts": {
+    "cstd": "./vendor/bin/phpcs --config-set installed_paths vendor/wp-coding-standards/wpcs",
+    "cs": "./vendor/bin/phpcs --standard=.phpcs.xml --report=summary .",
+    "cbf": "./vendor/bin/phpcbf --standard=.phpcs.xml ."
+  },
+  "require-dev": {
+    "squizlabs/php_codesniffer": "^3.7",
+    "wp-coding-standards/wpcs": "^2.3",
+    "phpcompatibility/php-compatibility": "^9.3"
+  }
+}

--- a/index.php
+++ b/index.php
@@ -1,2 +1,2 @@
-<?php 
+<?php
 // Silence is golden.

--- a/product-fields-admin.php
+++ b/product-fields-admin.php
@@ -9,7 +9,7 @@
  * License:           GPLv2 or later
  * License URI:       https://www.gnu.org/licenses/gpl.html
  * Text Domain:       product-fields-admin
- * 
+ *
  *  @package Product_Fields_Admin
  */
 


### PR DESCRIPTION
- [x] Added [Composer](https://getcomposer.org/) to handle packages;

- [X] Added packages to handle coding standards: [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) and [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards);

- [x] Added a  **.phpcs.xml file** to store the WordPress standards.

- [x] Minor refactor fixing WordPress Coding Standards violations.