### PR TITLE
Closes #9

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -10,7 +10,10 @@
     <arg name="extensions" value="php"/>
     <arg name="cache" value=".phpcs.cache"/>
 
-    <rule ref="WordPress"/>
+    <rule ref="WordPress">
+     <!-- PSR4 -->
+     <exclude name="WordPress.Files.FileName" />
+</rule>
 
     <rule ref="WordPress-Extra"/>
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     {
       "name": "sarahcssiqueira",
       "email": "sarahcosiqueira@gmail.com",
-      "homepage": "https://sarahjobs.com"
+      "homepage": "https://sarahsiqueira.com"
     }
   ],
   "support": {
@@ -16,7 +16,7 @@
   },
   "autoload": {
     "psr-4": {
-      "ProductFieldsAdmin\\Inc\\": "./inc"
+      "ProductCustomizationAddons\\Inc\\": "inc/"
     }
   },
   "require": {},

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -8,7 +8,7 @@
  * @package Product_Customization_Add-ons
  */
 
-namespace ProductFieldsAdmin\Inc;
+namespace ProductCustomizationAddons\Inc;
 
 /**
  * Class Admin

--- a/inc/Connect.php
+++ b/inc/Connect.php
@@ -8,7 +8,7 @@
  * @package Product_Customization_Add-ons
  */
 
-namespace ProductFieldsAdmin\Inc;
+namespace ProductCustomizationAddons\Inc;
 
 /**
  * Class Connect

--- a/inc/CustomFieldDataHandler.php
+++ b/inc/CustomFieldDataHandler.php
@@ -14,7 +14,7 @@
  *  @package Product_Customization_Add-ons
  */
 
-namespace ProductFieldsAdmin\Inc;
+namespace ProductCustomizationAddons\Inc;
 
 /**
  * Class CustomFieldDataHandler

--- a/inc/CustomFieldDisplayManager.php
+++ b/inc/CustomFieldDisplayManager.php
@@ -14,7 +14,7 @@
  * @package Product_Customization_Add-ons
  */
 
-namespace ProductFieldsAdmin\Inc;
+namespace ProductCustomizationAddons\Inc;
 
 /**
  * Class CustomFieldDisplayManager

--- a/inc/FieldsHandler.php
+++ b/inc/FieldsHandler.php
@@ -9,7 +9,7 @@
  * @package Product_Customization_Add-ons
  */
 
-namespace ProductFieldsAdmin\Inc;
+namespace ProductCustomizationAddons\Inc;
 
 /**
  * Class FieldsHandler

--- a/product-customization-add-ons.php
+++ b/product-customization-add-ons.php
@@ -17,26 +17,16 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Bootstrap the plugin by including necessary class files.
- *
- * This section initializes the core classes required for the plugin's functionality.
- * It includes the classes responsible for managing admin settings, custom fields,
- * data handling, and display logic.
+ * Composer Autoload
  */
+require __DIR__ . '/vendor/autoload.php';
 
-// Include necessary class files.
-require __DIR__ . '/inc/class-admin.php';
-require __DIR__ . '/inc/class-fields-handler.php';
-require __DIR__ . '/inc/class-connect.php';
-require __DIR__ . '/inc/class-custom-field-data-handler.php';
-require __DIR__ . '/inc/class-custom-field-display-manager.php';
-
-// Use classes from the ProductFieldsAdmin\Inc namespace.
-use ProductFieldsAdmin\Inc\Admin;
-use ProductFieldsAdmin\Inc\FieldsHandler;
-use ProductFieldsAdmin\Inc\Connect;
-use ProductFieldsAdmin\Inc\CustomFieldDataHandler;
-use ProductFieldsAdmin\Inc\CustomFieldDisplayManager;
+// Use classes from the ProductCustomizationAddons\Inc namespace.
+use ProductCustomizationAddons\Inc\FieldsHandler;
+use ProductCustomizationAddons\Inc\Admin;
+use ProductCustomizationAddons\Inc\Connect;
+use ProductCustomizationAddons\Inc\CustomFieldDataHandler;
+use ProductCustomizationAddons\Inc\CustomFieldDisplayManager;
 
 // Instantiate the necessary classes to activate the plugin's functionality.
 $fields_handler = new FieldsHandler();


### PR DESCRIPTION
- Adds composer autoload;
- Renamed classes for correct autoload loading;
- Updates **phpcs** to ignore class names rule as in [A workaround to handle PSR-4 && WordPress Coding Standards at same time](https://dev.to/sarahcssiqueira/a-workaround-to-handle-psr-4-wordpress-coding-standards-at-same-time-5ggk)
- Updates namespace.